### PR TITLE
Added Ubuntu Xenial Ansible ppa - now installing Ansible 2.4

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -11,6 +11,10 @@ fi
 
 # Install Ansible (if required)
 if ! [ -x "$(command -v ansible)" ]; then
+    echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main" \
+    >> /etc/apt/sources.list
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+    apt-get update
     apt-get install -y ansible
 fi
 


### PR DESCRIPTION
We need Ansible version 2.4
Have modified the script according to the instructions [here](http://docs.ansible.com/ansible/latest/intro_installation.html#latest-releases-via-apt-debian)
@Skeen Is it ok to merge this into master?